### PR TITLE
Tree seed drop rate json fix

### DIFF
--- a/assets/gloomeclasses/patches/leaves-branchy-seed-and-stick-dropmods.json
+++ b/assets/gloomeclasses/patches/leaves-branchy-seed-and-stick-dropmods.json
@@ -1,7 +1,7 @@
 [
   {
     "op": "addmerge",
-    "path": "/drops/0/quantityByType/dropModbyStat",
+    "path": "/drops/0/dropModbyStat",
     "value": "saplingDropRate",
     "file": "game:blocktypes/plant/leaves/branchy.json"
   },

--- a/assets/gloomeclasses/patches/leaves-normal-seed-and-stick-dropmods.json
+++ b/assets/gloomeclasses/patches/leaves-normal-seed-and-stick-dropmods.json
@@ -1,7 +1,7 @@
 [
   {
     "op": "addmerge",
-    "path": "/drops/0/quantityByType/dropModbyStat",
+    "path": "/drops/0/dropModbyStat",
     "value": "saplingDropRate",
     "file": "game:blocktypes/plant/leaves/normal.json"
   },


### PR DESCRIPTION
While testing class-based tree seed yield modifiers, I found that dropModByStat only applies when defined at the drop level (drops/0/dropModByStat or dropsByType/*/0/dropModByStat).

In the current implementation, dropModByStat is nested under quantityByType (for example drops/0/quantityByType/dropModByStat), which does not seem to be evaluated by the engine and results in the stat having no effect.

Moving dropModByStat up one level makes the modifier apply correctly while still respecting quantityByType.